### PR TITLE
Add simple docker build support for linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            muxiu1997/traefik-github-oauth-server:${{ steps.release.outputs.tag_name }}
-            muxiu1997/traefik-github-oauth-server:latest
+            ${{ vars.DOCKER_REPOSITORY }}:${{ steps.release.outputs.tag_name }}
+            ${{ vars.DOCKER_REPOSITORY }}:latest
 
       - name: Replace The Relative Path In The README.md
         if: ${{ steps.release.outputs.release_created }}
@@ -77,7 +77,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: muxiu1997/traefik-github-oauth-server
+          repository: ${{ vars.DOCKER_REPOSITORY }}
           short-description: server for traefik-github-oauth-plugin
           readme-filepath: docker.README.md
       # endregion Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           file: ./Dockerfile
           push: true
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
           tags: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.1.1](https://github.com/wurmr/traefik-github-oauth-plugin/compare/v0.3.0...v0.1.1) (2023-11-15)
+
+
+### Features
+
+* added variable for docker repostitory ([54d1970](https://github.com/wurmr/traefik-github-oauth-plugin/commit/54d1970bab52c6b68e128036db0bbe88b33bfb66))
+* implement traefik github oauth plugin ([d3be0a5](https://github.com/wurmr/traefik-github-oauth-plugin/commit/d3be0a5831ad83a7e8ceab47e0d6216902755313))
+* implement traefik github oauth server app ([7a7acdf](https://github.com/wurmr/traefik-github-oauth-plugin/commit/7a7acdf7f9822dee89225b3a17b3ac732bef5c94))
+* **middleware:** add log ([789e4cf](https://github.com/wurmr/traefik-github-oauth-plugin/commit/789e4cf0209aa13cd1aff5302a679686e63fcf29))
+* **middleware:** message when api secret key is invalid ([6138346](https://github.com/wurmr/traefik-github-oauth-plugin/commit/61383468b262150387da2f7a9598d8984a01dbde))
+* **middleware:** use `github.com/dghubble/sling` as http client ([81f461f](https://github.com/wurmr/traefik-github-oauth-plugin/commit/81f461fb35ed3fc5aa9d3441aec6c3a29e8f3db4))
+* **server:** add log ([48cf8ea](https://github.com/wurmr/traefik-github-oauth-plugin/commit/48cf8ea367d4c033918c2a4c2ca15148da1b32a8))
+* **server:** return request error message in json ([4c1eac9](https://github.com/wurmr/traefik-github-oauth-plugin/commit/4c1eac941db36e701f97d32335406b57bfafa860))
+* set no cache headers ([316878f](https://github.com/wurmr/traefik-github-oauth-plugin/commit/316878f0d3f2e8fa04a8eb6697c3a924eecd66c5))
+
+
+### Bug Fixes
+
+* **middleware:** redirect only on get requests ([61af42c](https://github.com/wurmr/traefik-github-oauth-plugin/commit/61af42ceb3917f44a0ef0aee5c2678fac670e164))
+* **server:** fix incorrect use of context ([788a2b0](https://github.com/wurmr/traefik-github-oauth-plugin/commit/788a2b0514bed2ae13252f60e104e9d3a4aa1ff2))
+* **server:** Fix logger middleware log fields ([3ccd7e3](https://github.com/wurmr/traefik-github-oauth-plugin/commit/3ccd7e38015495f2a91c31e2342d299baf86ae25))
+
 ## [0.3.0](https://github.com/MuXiu1997/traefik-github-oauth-plugin/compare/v0.2.2...v0.3.0) (2023-02-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/wurmr/traefik-github-oauth-plugin/compare/v0.1.1...v0.2.0) (2023-11-15)
+
+
+### Features
+
+* add arm/v7 support ([1dbbb86](https://github.com/wurmr/traefik-github-oauth-plugin/commit/1dbbb8600ed0da6621e996991698469870a22bcd))
+
 ## [0.1.1](https://github.com/wurmr/traefik-github-oauth-plugin/compare/v0.3.0...v0.1.1) (2023-11-15)
 
 


### PR DESCRIPTION
Because this touches the original repository's GitHub action workflow I am unable to test this completely before issuing the PR.

Fixes #22 